### PR TITLE
fix: requirements.txt for deployment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-r backend/requirements.txt


### PR DESCRIPTION
### Changes

- add `requirements.txt` to the root of the project for heroku deployment

The `requirements.txt` file in the root directory was removed in PR #38, as it seemed redundant when we also have `backend/requirements.txt`. However, the [Heroku Python buildpack](https://elements.heroku.com/buildpacks/heroku/heroku-buildpack-python), which we use to deploy the backend, _requires_ a `requirements.txt` file in the root of the repository. This is now re-added, but now redirects dependency installation to `backend/requirements.txt` instead of maintaining two divergent lists of dependencies as before.